### PR TITLE
Added support for limiting to a subdirectory of the repository

### DIFF
--- a/docs/gitinspector.1
+++ b/docs/gitinspector.1
@@ -92,6 +92,11 @@ Show which files the different authors seem most responsible for
 Only show statistics for commits more recent than a specific date
 .RE
 .PP
+\fB\-\-subpath\fR=PATH
+.RS 4
+Only show statistics for commits to files within this path
+.RE
+.PP
 \fB\-T, \-\-timeline\fR[=BOOL]
 .RS 4
 Show commit timeline, including author names

--- a/docs/gitinspector.html
+++ b/docs/gitinspector.html
@@ -36,6 +36,10 @@
 </span></dt><dd>
         Only show statistics for commits more recent than a specific date
 </dd><dt><span class="term">
+<span class="strong"><strong>--subpath</strong></span>=PATH
+</span></dt><dd>
+        Only show statistics for commits to files within this path
+</dd><dt><span class="term">
 <span class="strong"><strong>-T, --timeline</strong></span>[=BOOL]
 </span></dt><dd>
         Show commit timeline, including author names

--- a/docs/gitinspector.txt
+++ b/docs/gitinspector.txt
@@ -58,6 +58,9 @@ Mandatory arguments to long options are mandatory for short options too. Boolean
 *--since*=DATE::
 	Only show statistics for commits more recent than a specific date
 
+*--subpath*=PATH::
+	Only show statistics for commits to files within this path
+
 *-T, --timeline*[=BOOL]::
 	Show commit timeline, including author names
 

--- a/gitinspector/blame.py
+++ b/gitinspector/blame.py
@@ -29,6 +29,7 @@ import filtering
 import format
 import gravatar
 import interval
+import subpath
 import json
 import multiprocessing
 import re

--- a/gitinspector/blame.py
+++ b/gitinspector/blame.py
@@ -131,7 +131,7 @@ PROGRESS_TEXT = N_("Checking how many rows belong to each author (Progress): {0:
 class Blame:
 	def __init__(self, hard, useweeks, changes):
 		self.blames = {}
-		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()], bufsize=1,
+		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref(), subpath.get_subpath()], bufsize=1,
 		                             stdout=subprocess.PIPE).stdout
 		lines = ls_tree_r.readlines()
 

--- a/gitinspector/changes.py
+++ b/gitinspector/changes.py
@@ -28,6 +28,7 @@ import filtering
 import format
 import gravatar
 import interval
+import subpath
 import json
 import os
 import subprocess
@@ -109,7 +110,7 @@ class Changes:
 	def __init__(self, hard):
 		self.commits = []
 		git_log_r = subprocess.Popen(filter(None, ["git", "log", "--reverse", "--pretty=%cd|%H|%aN|%aE", "--stat=100000,8192", "--no-merges", "-w",
-		                             interval.get_since(), interval.get_until(), "--date=short"] + (["-C", "-C", "-M"] if hard else [])),
+		                             interval.get_since(), interval.get_until(), "--date=short"] + (["-C", "-C", "-M"] if hard else []) + [subpath.get_subpath()]),
 		                             bufsize=1, stdout=subprocess.PIPE).stdout
 		commit = None
 		found_valid_extension = False

--- a/gitinspector/config.py
+++ b/gitinspector/config.py
@@ -22,6 +22,7 @@ import extensions
 import filtering
 import format
 import interval
+import subpath
 import optval
 import os
 import subprocess
@@ -78,6 +79,10 @@ def init(run):
 	var = __read_git_config_string__(run.repo, "until")
 	if var[0]:
 		interval.set_until(var[1])
+
+	var = __read_git_config_string__(run.repo, "subpath")
+	if var[0]:
+		subpath.set_subpath(var[1])
 
 	run.timeline = __read_git_config_bool__(run.repo, "timeline")
 

--- a/gitinspector/gitinspector.py
+++ b/gitinspector/gitinspector.py
@@ -35,6 +35,7 @@ import filtering
 import format
 import help
 import interval
+import subpath
 import getopt
 import metrics
 import os
@@ -108,7 +109,7 @@ def main():
 		                                                 "hard:true", "help", "list-file-types:true",
 		                                                 "localize-output:true", "metrics:true", "responsibilities:true",
 		                                                 "since=", "grading:true", "timeline:true", "until=", "version",
-		                                                 "weeks:true"])
+		                                                 "subpath=", "weeks:true"])
 		for arg in __args__:
 			__run__.repo = arg
 
@@ -150,6 +151,8 @@ def main():
 				__run__.responsibilities = optval.get_boolean_argument(a)
 			elif o == "--since":
 				interval.set_since(a)
+			elif o == "--subpath":
+				subpath.set_subpath(a)
 			elif o == "--version":
 				version.output()
 				sys.exit(0)

--- a/gitinspector/help.py
+++ b/gitinspector/help.py
@@ -55,6 +55,8 @@ Boolean arguments can only be given to long options.
                                    most responsible for
       --since=DATE               only show statistics for commits more recent
                                    than a specific date
+      --subpath=PATH             only show statistics for commits to files
+                                   within this path
   -T, --timeline[=BOOL]          show commit timeline, including author names
       --until=DATE               only show statistics for commits older than a
                                    specific date


### PR DESCRIPTION
This is useful for larger projects where development may have progressed independently on different areas, particularly with the timeline view
