### PR TITLE
Recognise Lilypond (.ly and .ily) comments

### DIFF
--- a/gitinspector/comment.py
+++ b/gitinspector/comment.py
@@ -22,16 +22,16 @@ from __future__ import unicode_literals
 __comment_begining__ = {"java": "/*", "c": "/*", "cc": "/*", "cpp": "/*", "cs": "/*", "h": "/*", "hh": "/*", "hpp": "/*",
                         "hs": "{-", "html": "<!--", "php": "/*", "py": "\"\"\"", "glsl": "/*", "rb": "=begin", "js": "/*",
                         "jspx": "<!--", "scala": "/*", "sql": "/*", "tex": "\\begin{comment}", "xhtml": "<!--",
-                        "xml": "<!--", "ml": "(*", "mli": "(*", "go": "/*"}
+                        "xml": "<!--", "ml": "(*", "mli": "(*", "go": "/*", "ly": "%{", "ily": "%{"}
 
 __comment_end__ = {"java": "*/", "c": "*/", "cc": "*/", "cpp": "*/", "cs": "*/", "h": "*/", "hh": "*/", "hpp": "*/", "hs": "-}",
                    "html": "-->", "php": "/*", "py": "\"\"\"", "glsl": "*/", "rb": "=end", "js": "*/", "jspx": "-->",
                    "scala": "*/", "sql": "*/", "tex": "\\end{comment}", "xhtml": "-->", "xml": "-->", "ml": "*)", "mli": "*)",
-                   "go": "*/"}
+                   "go": "*/", "ly": "%}", "ily": "%}"}
 
 __comment__ = {"java": "//", "c": "//", "cc": "//", "cpp": "//", "cs": "//", "h": "//", "hh": "//", "hpp": "//", "hs": "--",
                "pl": "#", "php": "//", "py": "#", "glsl": "//", "rb": "#", "robot": "#", "js": "//", "scala": "//", "sql": "--",
-               "tex": "%", "ada": "--", "ads": "--", "adb": "--", "pot": "#", "po": "#", "go": "//"}
+               "tex": "%", "ada": "--", "ads": "--", "adb": "--", "pot": "#", "po": "#", "go": "//", "ly": "%", "ily": "%"}
 
 __comment_markers_must_be_at_begining__ = {"tex": True}
 


### PR DESCRIPTION
Added comment definitions for [Lilypond](http://www.lilypond.org) (.ly and .ily) files to comment.py. Some people use Lilypond with Git for collaborative music engraving.