### PR TITLE
fix some errors

### DIFF
--- a/gitinspector/changes.py
+++ b/gitinspector/changes.py
@@ -219,7 +219,8 @@ class Changes(object):
 		for i in range(0, NUM_THREADS):
 			__thread_lock__.release()
 
-		self.commits = [item for sublist in self.commits for item in sublist]
+		sublist = [sub for sub in self.commits if sub is not None]
+		self.commits = [item for s in sublist for item in s]
 
 		if len(self.commits) > 0:
 			if interval.has_interval() and len(self.commits) > 0:
@@ -229,6 +230,8 @@ class Changes(object):
 			                                       int(self.commits[0].date[8:10]))
 			self.last_commit_date = datetime.date(int(self.commits[-1].date[0:4]), int(self.commits[-1].date[5:7]),
 			                                      int(self.commits[-1].date[8:10]))
+			else:
+				interval.set_ref('HEAD')
 
 	def __iadd__(self, other):
 		try:

--- a/gitinspector/gitinspector.py
+++ b/gitinspector/gitinspector.py
@@ -82,22 +82,22 @@ class Runner(object):
 		format.output_header(repos)
 		outputable.output(ChangesOutput(summed_changes))
 
-		if changes.get_commits():
-			outputable.output(BlameOutput(summed_changes, summed_blames))
+		#if changes.get_commits():
+		outputable.output(BlameOutput(summed_changes, summed_blames))
 
-			if self.timeline:
-				outputable.output(TimelineOutput(summed_changes, self.useweeks))
+		if self.timeline:
+			outputable.output(TimelineOutput(summed_changes, self.useweeks))
 
-			if self.include_metrics:
-				outputable.output(MetricsOutput(summed_metrics))
+		if self.include_metrics:
+			outputable.output(MetricsOutput(summed_metrics))
 
-			if self.responsibilities:
-				outputable.output(ResponsibilitiesOutput(summed_changes, summed_blames))
+		if self.responsibilities:
+			outputable.output(ResponsibilitiesOutput(summed_changes, summed_blames))
 
-			outputable.output(FilteringOutput())
+		outputable.output(FilteringOutput())
 
-			if self.list_file_types:
-				outputable.output(ExtensionsOutput())
+		if self.list_file_types:
+			outputable.output(ExtensionsOutput())
 
 		format.output_footer()
 		os.chdir(previous_directory)


### PR DESCRIPTION
Fix some errors with multiple projects,  if second project is empty:
1. The ref will not be initial.
2. Blame information will not shown.
3. Fix Nonetype in commits.
