### PR TITLE
Added Korean Translation file (for fixing #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Below are some example outputs for a number of famous open source projects. All 
   * Agustín Cañas, Spanish translation
   * Bill Wang, Chinese translation
   * Christian Kastner, Debian package maintainer
-  * Jiwon Kim, Korean translation
+  * Moses Kim, Korean translation
   * Kamila Chyla, Polish translation
   * Luca Motta, Italian translation
   * Philipp Nowak, German translation

--- a/gitinspector/translations/messages_ko.po
+++ b/gitinspector/translations/messages_ko.po
@@ -20,7 +20,7 @@
 # xgettext --no-wrap -s -w 140 --language=Python --keyword="N_"
 # --no-location --output=messages.pot *.py
 #
-# Moses kim <creatinov.kim@gmail.com>, 2016
+# Moses Kim <creatinov.kim@gmail.com>, 2016
 
 msgid ""
 msgstr ""

--- a/gitinspector/translations/messages_ko.po
+++ b/gitinspector/translations/messages_ko.po
@@ -1,0 +1,318 @@
+# Copyright © 2012-2015 Ejwa Software. All rights reserved.
+#
+# This file is part of gitinspector.
+#
+# gitinspector is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gitinspector is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the following command:
+#
+# xgettext --no-wrap -s -w 140 --language=Python --keyword="N_"
+# --no-location --output=messages.pot *.py
+#
+# Moses kim <creatinov.kim@gmail.com>, 2016
+
+msgid ""
+msgstr ""
+"Project-Id-Version: gitinspector 0.5.0dev\n"
+"Report-Msgid-Bugs-To: gitinspector@ejwa.se\n"
+"POT-Creation-Date: 2015-10-02 03:35+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Adam Waldenberg <adam.waldenberg@ejwa.se>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#, python-format
+msgid "% in comments"
+msgstr "% in comments"
+
+#, python-format
+msgid "% of changes"
+msgstr "% of changes"
+
+msgid "(extensions used during statistical analysis are marked)"
+msgstr "(통계 분석 진행 과정에서 사용된 확장자들은 굵게 표시됩니다)"
+
+msgid "Age"
+msgstr "수명"
+
+msgid "Author"
+msgstr "작성자"
+
+msgid "Below are the number of rows from each author that have survived and are still intact in the current revision"
+msgstr "아래의 숫자들은 각 작성자들이 작성한 코드 중 현재 리비전에서 접근 가능한 라인 수입니다."
+
+#, python-brace-format
+msgid "Checking how many rows belong to each author (Progress): {0:.0f}%"
+msgstr "각 작성자가 얼마나 많은 코드 라인을  작성했는지 확인하고 있습니다 (진행율): {0:.0f}% "
+
+msgid "Commits"
+msgstr "Commits"
+
+msgid ""
+"Copyright © 2012-2015 Ejwa Software. All rights reserved.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\n"
+"This is free software: you are free to change and redistribute it.\n"
+"There is NO WARRANTY, to the extent permitted by law.\n"
+"\n"
+"Written by Adam Waldenberg."
+msgstr ""
+"Copyright © 2012-2015 Ejwa Software. 모든 권리는 보존됩니다.\n"
+"License GPLv3+: GNU GPL version 3 이상 <http://gnu.org/licenses/gpl.html>.\n"
+"이 소프트웨어는 무료입니다: 자유롭게 변경하고 재배포할 수 있습니다.\n"
+"이 소프트웨어는 법적인 보증을 하지 않습니다.\n"
+"\n"
+"Adam Waldenberg가 개발했습니다."
+
+msgid "Deletions"
+msgstr "삭제 수"
+
+#, python-format
+msgid "Error processing git repository at \"%s\"."
+msgstr "깃 저장소(\"%s\")를 처리하는 도중 오류가 발생했습니다."
+
+msgid "HTML output not yet supported in"
+msgstr "HTML 출력은 다음에서 아직 지원하지 않습니다: "
+
+msgid "Hide minor authors"
+msgstr "코드 작업량이 미미한 작성자 숨김"
+
+msgid "Hide rows with minor work"
+msgstr "코드 작업량이 미미한 행 숨김"
+
+msgid "Insertions"
+msgstr "삽입 수"
+
+msgid "Minor Authors"
+msgstr "코드 작업량이 미미한 작성자"
+
+msgid "Modified Rows:"
+msgstr "수정된 행들:"
+
+msgid "No commited files with the specified extensions were found"
+msgstr "지정한 확장자를 가진 커밋 파일들을 발견하지 못했습니다"
+
+msgid "No metrics violations were found in the repository"
+msgstr "저장소에서 메트릭 위반을 발견하지 못했습니다"
+
+#, python-brace-format
+msgid "Repository statistics for {0}"
+msgstr "{0}에 대한 저장소 통계"
+
+msgid "Rows"
+msgstr "행"
+
+msgid "Show minor authors"
+msgstr "코드 작업량이 적은 작성자 표시"
+
+msgid "Show rows with minor work"
+msgstr "코드 작업량이 적은 행 표시"
+
+msgid "Stability"
+msgstr "안정성"
+
+#, python-brace-format
+msgid "Statistical information for the repository '{0}' was gathered on {1}."
+msgstr "저장소 '{0}'에 대한 정보를 {1}에 수집하였습니다."
+
+msgid "Text output not yet supported in"
+msgstr "Text 출력은 다음에서 아직 지원하지 않습니다: "
+
+msgid "The authors with the following emails were excluded from the statistics due to the specified exclusion patterns"
+msgstr "다음 이메일은 제외 패턴으로 지정되었기 때문에, 해당 이메일 주소를 사용하는 작성자들은 통계에서 제외하였습니다"
+
+msgid "The extensions below were found in the repository history"
+msgstr "저장소 이력에서 다음 확장자들을 발견하였습니다"
+
+msgid "The following authors were excluded from the statistics due to the specified exclusion patterns"
+msgstr "다음 작성자들은 제외 패턴으로 지정되었기 때문에 통계에서 제외하였습니다"
+
+msgid "The following commit revisions were excluded from the statistics due to the specified exclusion patterns"
+msgstr "다음 커밋 리비전들은 제외 패턴으로 지정되었기 때문에 통계에서 제외하였습니다"
+
+msgid "The following files are suspiciously big (in order of severity)"
+msgstr "다음 파일들의 크기가 너무 큰 것으로 의심됩니다 (심각도 순서)"
+
+msgid "The following files have an elevated cyclomatic complexity (in order of severity)"
+msgstr "다음 파일들의 순환 복잡도가 매우 높습니다 (심각도 순서)"
+
+msgid "The following files have an elevated cyclomatic complexity density (in order of severity)"
+msgstr "다음 파일들의 순환 복잡도 밀도가 매우 높습니다 (심각도 순서)"
+
+msgid "The following files were excluded from the statistics due to the specified exclusion patterns"
+msgstr "다음 파일들은 제외 패턴으로 지정되었기 때문에 통계에서 제외하였습니다"
+
+msgid "The following historical commit information, by author, was found in the repository"
+msgstr "다음의 작성자별 커밋 정보 기록을 해당 저장소에서 찾을 수 없습니다"
+
+msgid "The following history timeline has been gathered from the repository"
+msgstr "다음의 타임라인 기록을 해당 저장소에서 수집하였습니다"
+
+msgid "The following responsibilities, by author, were found in the current revision of the repository (comments are excluded from the line count, if possible)"
+msgstr "저장소의 현재 버전에서 다음과 같은 작상자별 책임 사항을 발견했습니다(주석은 가능한 라인 수에서 제외하였습니다)"
+
+msgid "The given option argument is not a valid boolean."
+msgstr "입력한 설정인자가 유효한 부울형(boolean)이 아닙니다"
+
+#, python-brace-format
+msgid "The output has been generated by {0} {1}. The statistical analysis tool for git repositories."
+msgstr "{0} {1}에 의한 출력 결과입니다. git 저장소들에 사용 가능한 통계 분석 도구입니다."
+
+#, python-brace-format
+msgid "Try `{0} --help' for more information."
+msgstr "자세한 정보를 원하실 경우 '{0} --help'를 실행하십시오."
+
+msgid "Unable to determine absolute path of git repository."
+msgstr "git 저장소의 절대 경로를 확인할 수 없습니다."
+
+#, python-brace-format
+msgid ""
+"Usage: {0} [OPTION]... [REPOSITORY]\n"
+"List information about the repository in REPOSITORY. If no repository is\n"
+"specified, the current directory is used. If multiple repositories are\n"
+"given, information will be fetched from the last repository specified.\n"
+"\n"
+"Mandatory arguments to long options are mandatory for short options too.\n"
+"Boolean arguments can only be given to long options.\n"
+"  -f, --file-types=EXTENSIONS    a comma separated list of file extensions to\n"
+"                                   include when computing statistics. The\n"
+"                                   default extensions used are:\n"
+"                                   {1}\n"
+"                                   Specifying * includes files with no\n"
+"                                   extension, while ** includes all files\n"
+"  -F, --format=FORMAT            define in which format output should be\n"
+"                                   generated; the default format is 'text' and\n"
+"                                   the available formats are:\n"
+"                                   {2}\n"
+"      --grading[=BOOL]           show statistics and information in a way that\n"
+"                                   is formatted for grading of student\n"
+"                                   projects; this is the same as supplying the\n"
+"                                   options -HlmrTw\n"
+"  -H, --hard[=BOOL]              track rows and look for duplicates harder;\n"
+"                                   this can be quite slow with big repositories\n"
+"  -l, --list-file-types[=BOOL]   list all the file extensions available in the\n"
+"                                   current branch of the repository\n"
+"  -L, --localize-output[=BOOL]   localize the generated output to the selected\n"
+"                                   system language if a translation is\n"
+"                                   available\n"
+"  -m  --metrics[=BOOL]           include checks for certain metrics during the\n"
+"                                   analysis of commits\n"
+"  -r  --responsibilities[=BOOL]  show which files the different authors seem\n"
+"                                   most responsible for\n"
+"      --since=DATE               only show statistics for commits more recent\n"
+"                                   than a specific date\n"
+"  -T, --timeline[=BOOL]          show commit timeline, including author names\n"
+"      --until=DATE               only show statistics for commits older than a\n"
+"                                   specific date\n"
+"  -w, --weeks[=BOOL]             show all statistical information in weeks\n"
+"                                   instead of in months\n"
+"  -x, --exclude=PATTERN          an exclusion pattern describing the file\n"
+"                                   paths, revisions, revisions with certain\n"
+"                                   commit messages, author names or author\n"
+"                                   emails that should be excluded from the\n"
+"                                   statistics; can be specified multiple times\n"
+"  -h, --help                     display this help and exit\n"
+"      --version                  output version information and exit\n"
+"\n"
+"gitinspector will filter statistics to only include commits that modify,\n"
+"add or remove one of the specified extensions, see -f or --file-types for\n"
+"more information.\n"
+"\n"
+"gitinspector requires that the git executable is available in your PATH.\n"
+"Report gitinspector bugs to gitinspector@ejwa.se."
+msgstr ""
+"사용법: {0} [OPTION]... [REPOSITORY]\n"
+"REPOSITORY에 입력한 저장소와 관련된 정보를 리스트합니다.\n"
+"저장소를 입력하지 않을 경우, 현재 디렉토리 경로를 사용합니다.\n"
+"두 개 이상의 저장소를 입력하는 경우, 가장 마지막에 입력한 저장소와 관련된 정보를 표시합니다.\n"
+"\n"
+"긴 옵션에 필수적으로 필요한 인자는 짧은 옵션에도 동일하게 필수적으로 적용됩니다.\n"
+"부울형(boolean) 인자는 긴 옵션에서만 사용할 수 있습니다.\n"
+"  -f, --file-types=EXTENSIONS    콤마(,)로 구분된 확장자 리스트로 통계값 계산 시\n"
+"                                   포함하는 파일의 확장자를 의미합니다.\n"
+"                                   기본 확장자 값은 다음과 같습니다:\n"
+"                                   {1}\n"
+"                                   애스터리스크(*)는 확장자가 없는 파일을 포함하며,\n"
+"                                   **는 모든 파일들을 포함합니다.\n"
+"  -F, --format=FORMAT            출력 형태를 지정합니다;\n"
+"                                   기본 출력 형태는 'text'입니다.\n"
+"                                   추가로 활용 가능한 출력 형태는 다음과 같습니다:\n"
+"                                   {2}\n"
+"      --grading[=BOOL]           학생들이 개발한 프로젝트를 평가하기 적당한 형태로\n"
+"                                   통계와 정보를 출력합니다;\n"
+"                                   이 옵션을 사용하면 다음 옵션을 사용한 것과 동일한 결과를 얻습니다:\n"
+"                                   -HlmrTw\n"
+"  -H, --hard[=BOOL]              중복된 코드 라인을 더 면밀하게 확인합니다;\n"
+"                                   큰 저장소에 사용할 경우 분석 속도가 느려질 수 있습니다.\n"
+"  -l, --list-file-types[=BOOL]   저장소의 현재 브랜치에 존재하는 모든 파일의\n"
+"                                   확장자를 표시합니다.\n"
+"  -L, --localize-output[=BOOL]   사용 중인 시스템 로케일 언어로\n"
+"                                   분석 결과를 출력합니다. 단 해당 로케일 언어의\n"
+"                                   번역본이 존재해야 합니다.\n"
+"  -m  --metrics[=BOOL]           커밋을 분석하는 과정에서 특정 지표를\n"
+"                                   확인합니다.\n"
+"  -r  --responsibilities[=BOOL]  코드 작성자들이 어떤 코드들에 가장 책임을 많이\n"
+"                                   가지고 있는지를 표시합니다.\n"
+"      --since=DATE               지정한 날짜 이후의 커밋과 관련된\n"
+"                                   통계 정보를 표시합니다(지정일 포함).\n"
+"  -T, --timeline[=BOOL]          작성자 이름을 포함해 커밋 타임라인을 표시합니다.\n"
+"      --until=DATE               지정한 날짜 이전의 커밋과 관련된\n"
+"                                   통계 정보를 표시합니다(지정일 불포함).\n"
+"  -w, --weeks[=BOOL]             통계 자료를 월 단위가 대신\n"
+"                                   주 단위로 표시합니다.\n"
+"  -x, --exclude=PATTERN          통계 자료에서 제외하고자 하는 패턴을 입력합니다.\n"
+"                                   파일 경로, 리비전, 특정 커밋 메시지를 포함한 리비전,\n"
+"                                   작성자 이름 혹은 작성자 이메일등을\n"
+"                                   사용할 수 있습니다;\n"
+"                                   패턴은 여러번 지정할 수 있습니다.\n"
+"  -h, --help                     이 도움말을 표시하고 종료합니다.\n"
+"      --version                  이 소프트웨어의 버전을 표시하고 종료합니다.\n"
+"\n"
+"gitinspector는 지정된 확장자를 가진 파일에서 수정(modify), 추가(add) 혹은 삭제(remove)와 관련된\n"
+"커밋에 관한 통계 정보만을 필터링합니다. 더 많은 정보를 보고 싶다면,\n"
+"-f 혹은 --file-types 옵션을 사용하십시오.\n"
+"\n"
+"gitinspector를 사용하기 위해서는 여러분이 사용하는 PATH 변수에 git 실행 파일이 지정되어 있어야 합니다.\n"
+"gitinpsector 관련 버그는 gitinspector@ejwa.se 로 보내 주십시오."
+
+msgid "WARNING: The terminal encoding is not correctly configured. gitinspector might malfunction. The encoding can be configured with the environment variable 'PYTHONIOENCODING'."
+msgstr "경고: 터미널 인코딩이 지정되지 않았습니다. gitinspector가 오동작 할 수 있습니다. 터미널 인코딩은 'PYTHONIOENCODING' 환경 변수에서 지정할 수 있습니다."
+
+msgid "XML output not yet supported in"
+msgstr "XML 출력은 다음에서 아직 지원하지 않습니다: "
+
+#, python-brace-format
+msgid "gitinspector requires at least Python 2.6 to run (version {0} was found)."
+msgstr "gitinpector는 Python 2.6 버전 이상에서 동작합니다 (현재 버전: {0})."
+
+msgid "invalid regular expression specified"
+msgstr "유효하지 않은 정규식이 사용되었습니다"
+
+msgid "is mostly responsible for"
+msgstr "는 다음에 대해 가장 큰 책임이 있습니다: "
+
+msgid "specified output format not supported."
+msgstr "지정한 출력 포맷을 지원하지 않습니다"
+
+#, python-brace-format
+msgid "{0} ({1:.3f} in cyclomatic complexity density)"
+msgstr "{0} (순환 복잡도 밀도로 표현 시: {1:.3f})"
+
+#, python-brace-format
+msgid "{0} ({1} estimated lines of code)"
+msgstr "{0} (추정된 코드 라인 수: {1})"
+
+#, python-brace-format
+msgid "{0} ({1} in cyclomatic complexity)"
+msgstr "{0} (순환 복잡도로 표현 시: {1})"


### PR DESCRIPTION
This PR offers a Korean translation of the gitinspector application (as referenced in #51).
- added messages_ko.po
- modified README.md for changing member or Korean translation

Any feedback would be appreciated.

Regards.
