### PR TITLE
Remove global interval.__ref__ to avoid race

### DIFF
--- a/gitinspector/blame.py
+++ b/gitinspector/blame.py
@@ -123,7 +123,7 @@ PROGRESS_TEXT = N_("Checking how many rows belong to each author (2 of 2): {0:.0
 class Blame(object):
 	def __init__(self, repo, hard, useweeks, changes):
 		self.blames = {}
-		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()], bufsize=1,
+		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", changes.ref], bufsize=1,
 		                             stdout=subprocess.PIPE).stdout
 		lines = ls_tree_r.readlines()
 		ls_tree_r.close()
@@ -141,7 +141,7 @@ class Blame(object):
 			   filtering.set_filtered(FileDiff.get_filename(row)):
 				blame_command = filter(None, ["git", "blame", "--line-porcelain", "-w"] + \
 						(["-C", "-C", "-M"] if hard else []) +
-				                [interval.get_since(), interval.get_ref(), "--", row])
+				                [interval.get_since(), changes.ref, "--", row])
 				thread = BlameThread(useweeks, changes, blame_command, FileDiff.get_extension(row),
 				                     self.blames, row.strip())
 				thread.daemon = True

--- a/gitinspector/blame.py
+++ b/gitinspector/blame.py
@@ -123,9 +123,10 @@ PROGRESS_TEXT = N_("Checking how many rows belong to each author (2 of 2): {0:.0
 class Blame(object):
 	def __init__(self, repo, hard, useweeks, changes):
 		self.blames = {}
-		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", changes.ref], bufsize=1,
+		ls_tree_r = subprocess.Popen(["git", "ls-tree", "-r", changes.ref], bufsize=1,
 		                             stdout=subprocess.PIPE).stdout
-		lines = ls_tree_r.readlines()
+                # skip submodules
+		lines = [ l.split("\t",1)[-1] for l in ls_tree_r.readlines() if not l.startswith("160000") ]
 		ls_tree_r.close()
 
 		progress_text = _(PROGRESS_TEXT)

--- a/gitinspector/changes.py
+++ b/gitinspector/changes.py
@@ -180,6 +180,7 @@ class Changes(object):
 	authors_dateinfo = {}
 	authors_by_email = {}
 	emails_by_author = {}
+	ref = "HEAD"
 
 	def __init__(self, repo, hard):
 		self.commits = []
@@ -223,7 +224,7 @@ class Changes(object):
 
 		if len(self.commits) > 0:
 			if interval.has_interval() and len(self.commits) > 0:
-				interval.set_ref(self.commits[-1].sha)
+				self.ref = self.commits[-1].sha
 
 			self.first_commit_date = datetime.date(int(self.commits[0].date[0:4]), int(self.commits[0].date[5:7]),
 			                                       int(self.commits[0].date[8:10]))

--- a/gitinspector/gitinspector.py
+++ b/gitinspector/gitinspector.py
@@ -72,7 +72,7 @@ class Runner(object):
 			summed_changes += changes
 
 			if self.include_metrics:
-				summed_metrics += MetricsLogic()
+				summed_metrics += MetricsLogic(changes.ref)
 
 			if sys.stdout.isatty() and format.is_interactive_format():
 				terminal.clear_row()

--- a/gitinspector/interval.py
+++ b/gitinspector/interval.py
@@ -28,8 +28,6 @@ __since__ = ""
 
 __until__ = ""
 
-__ref__ = "HEAD"
-
 def has_interval():
 	return __since__ + __until__ != ""
 
@@ -47,9 +45,3 @@ def set_until(until):
 	global __until__
 	__until__ = "--until=" + quote(until)
 
-def get_ref():
-	return __ref__
-
-def set_ref(ref):
-	global __ref__
-	__ref__ = ref

--- a/gitinspector/metrics.py
+++ b/gitinspector/metrics.py
@@ -39,12 +39,12 @@ METRIC_CYCLOMATIC_COMPLEXITY_THRESHOLD = 50
 METRIC_CYCLOMATIC_COMPLEXITY_DENSITY_THRESHOLD = 0.75
 
 class MetricsLogic(object):
-	def __init__(self):
+	def __init__(self, ref):
 		self.eloc = {}
 		self.cyclomatic_complexity = {}
 		self.cyclomatic_complexity_density = {}
 
-		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()], bufsize=1,
+		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", ref], bufsize=1,
 		                             stdout=subprocess.PIPE).stdout
 
 		for i in ls_tree_r.readlines():
@@ -53,7 +53,7 @@ class MetricsLogic(object):
 			i = i.decode("utf-8", "replace").strip("\"").strip("'").strip()
 
 			if FileDiff.is_valid_extension(i) and not filtering.set_filtered(FileDiff.get_filename(i)):
-				file_r = subprocess.Popen(["git", "show", interval.get_ref() + ":{0}".format(i.strip())],
+				file_r = subprocess.Popen(["git", "show", ref + ":{0}".format(i.strip())],
 				                          bufsize=1, stdout=subprocess.PIPE).stdout.readlines()
 
 				extension = FileDiff.get_extension(i)

--- a/gitinspector/metrics.py
+++ b/gitinspector/metrics.py
@@ -44,10 +44,14 @@ class MetricsLogic(object):
 		self.cyclomatic_complexity = {}
 		self.cyclomatic_complexity_density = {}
 
-		ls_tree_r = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", ref], bufsize=1,
+		ls_tree_r = subprocess.Popen(["git", "ls-tree", "-r", ref], bufsize=1,
 		                             stdout=subprocess.PIPE).stdout
+  
+
 
 		for i in ls_tree_r.readlines():
+			if i.startswith("160000"): continue  # skip submodules
+			i = i.split("\t")[-1]
 			i = i.strip().decode("unicode_escape", "ignore")
 			i = i.encode("latin-1", "replace")
 			i = i.decode("utf-8", "replace").strip("\"").strip("'").strip()


### PR DESCRIPTION
previously it was broken when multiple repos where exemined and '--since' was used: global `interval.__ref__` was set to a commit ID valid for only one last examined repo, making it fail for all others
