### PR TITLE
Adds '.go' (for the programming language Go) as default

### DIFF
--- a/gitinspector/extensions.py
+++ b/gitinspector/extensions.py
@@ -19,7 +19,7 @@
 
 from __future__ import unicode_literals
 
-DEFAULT_EXTENSIONS = ["java", "c", "cc", "cpp", "h", "hh", "hpp", "py", "glsl", "rb", "js", "sql"]
+DEFAULT_EXTENSIONS = ["java", "c", "cc", "cpp", "h", "hh", "hpp", "py", "glsl", "rb", "js", "sql", "go"]
 
 __extensions__ = DEFAULT_EXTENSIONS
 __located_extensions__ = set()


### PR DESCRIPTION
Simply adds the file extension '.go' as a default. This is the default extension for the programming language [Go](https://golang.org). I do a lot of programming in Go and I like to use gitinspector - and it's annoying to do `-f go` every time. 

I totally understand if this is too small to include in the project or if you don't think Go belongs as a default in gitinspector - but hey, I wanted to give it a shot :smile: 