### PR TITLE
Guard against exceptions when commits is None due to extension filtering

### DIFF
--- a/gitinspector/changes.py
+++ b/gitinspector/changes.py
@@ -160,9 +160,10 @@ class ChangesThread(threading.Thread):
 				   filtering.set_filtered(commit.sha, "message")):
 					is_filtered = True
 
-			if FileDiff.is_filediff_line(j) and not \
-			   filtering.set_filtered(FileDiff.get_filename(j)) and not is_filtered:
-				extensions.add_located(FileDiff.get_extension(j))
+			if commit is not None:
+				if FileDiff.is_filediff_line(j) and not \
+				filtering.set_filtered(FileDiff.get_filename(j)) and not is_filtered:
+					extensions.add_located(FileDiff.get_extension(j))
 
 				if FileDiff.is_valid_extension(j):
 					found_valid_extension = True
@@ -198,18 +199,14 @@ class Changes(object):
 			first_hash = ""
 
 			for i, entry in enumerate(lines):
-				if i % CHANGES_PER_THREAD == CHANGES_PER_THREAD - 1:
-					entry = entry.decode("utf-8", "replace").strip()
-					second_hash = entry
-					ChangesThread.create(hard, self, first_hash, second_hash, i)
-					first_hash = entry + ".."
-
-					if format.is_interactive_format():
-						terminal.output_progress(progress_text, i, len(lines))
-			else:
 				entry = entry.decode("utf-8", "replace").strip()
 				second_hash = entry
 				ChangesThread.create(hard, self, first_hash, second_hash, i)
+				if i % CHANGES_PER_THREAD == CHANGES_PER_THREAD - 1:
+					first_hash = entry + ".."
+					if format.is_interactive_format():
+						terminal.output_progress(progress_text, i, len(lines))
+
 
 		# Make sure all threads have completed.
 		for i in range(0, NUM_THREADS):
@@ -220,15 +217,22 @@ class Changes(object):
 			__thread_lock__.release()
 
 		self.commits = [item for sublist in self.commits for item in sublist]
+		flatten = lambda l: [item for sublist in l for item in sublist]
+		self.commits = [x for x in flatten(self.commits) if x is not None]
 
-		if len(self.commits) > 0:
-			if interval.has_interval() and len(self.commits) > 0:
-				interval.set_ref(self.commits[-1].sha)
+		if self.commits:
+			first = self.commits[0]
+			last = self.commits[-1]
 
-			self.first_commit_date = datetime.date(int(self.commits[0].date[0:4]), int(self.commits[0].date[5:7]),
-			                                       int(self.commits[0].date[8:10]))
-			self.last_commit_date = datetime.date(int(self.commits[-1].date[0:4]), int(self.commits[-1].date[5:7]),
-			                                      int(self.commits[-1].date[8:10]))
+			if first and last:
+				if interval.has_interval() and last:
+					interval.set_ref(last.sha)
+				self.first_commit_date = self.get_commit_date(first)
+				self.last_commit_date = self.get_commit_date(last)
+
+	@classmethod
+	def get_commit_date(cls, commit):
+		return datetime.date(int(commit.date[0:4]), int(commit.date[5:7]), int(commit.date[8:10]))
 
 	def __iadd__(self, other):
 		try:

--- a/gitinspector/comment.py
+++ b/gitinspector/comment.py
@@ -22,17 +22,17 @@ from __future__ import unicode_literals
 __comment_begining__ = {"java": "/*", "c": "/*", "cc": "/*", "cpp": "/*", "cs": "/*", "h": "/*", "hh": "/*", "hpp": "/*",
                         "hs": "{-", "html": "<!--", "php": "/*", "py": "\"\"\"", "glsl": "/*", "rb": "=begin", "js": "/*",
                         "jspx": "<!--", "scala": "/*", "sql": "/*", "tex": "\\begin{comment}", "xhtml": "<!--",
-                        "xml": "<!--", "ml": "(*", "mli": "(*", "go": "/*", "ly": "%{", "ily": "%{"}
+                        "xml": "<!--", "ml": "(*", "mli": "(*", "go": "/*", "ly": "%{", "ily": "%{", "groovy": "/*"}
 
 __comment_end__ = {"java": "*/", "c": "*/", "cc": "*/", "cpp": "*/", "cs": "*/", "h": "*/", "hh": "*/", "hpp": "*/", "hs": "-}",
                    "html": "-->", "php": "/*", "py": "\"\"\"", "glsl": "*/", "rb": "=end", "js": "*/", "jspx": "-->",
                    "scala": "*/", "sql": "*/", "tex": "\\end{comment}", "xhtml": "-->", "xml": "-->", "ml": "*)", "mli": "*)",
-                   "go": "*/", "ly": "%}", "ily": "%}"}
+                   "go": "*/", "ly": "%}", "ily": "%}", "groovy": "*/"}
 
 __comment__ = {"java": "//", "c": "//", "cc": "//", "cpp": "//", "cs": "//", "h": "//", "hh": "//", "hpp": "//", "hs": "--",
                "pl": "#", "php": "//", "py": "#", "glsl": "//", "rb": "#", "robot": "#", "rs": "//", "rlib": "//", "js": "//",
                "scala": "//", "sql": "--", "tex": "%", "ada": "--", "ads": "--", "adb": "--", "pot": "#", "po": "#", "go": "//",
-               "ly": "%", "ily": "%"}
+               "ly": "%", "ily": "%", "groovy": "//"}
 
 __comment_markers_must_be_at_begining__ = {"tex": True}
 

--- a/gitinspector/metrics.py
+++ b/gitinspector/metrics.py
@@ -24,9 +24,9 @@ from .changes import FileDiff
 from . import comment, filtering, interval
 
 __metric_eloc__ = {"java": 500, "c": 500, "cpp": 500, "cs": 500, "h": 300, "hpp": 300, "php": 500, "py": 500, "glsl": 1000,
-                   "rb": 500, "js": 500, "sql": 1000, "xml": 1000}
+                   "rb": 500, "js": 500, "sql": 1000, "xml": 1000, "groovy": 500}
 
-__metric_cc_tokens__ = [[["java", "js", "c", "cc", "cpp"], ["else", r"for\s+\(.*\)", r"if\s+\(.*\)", r"case\s+\w+:",
+__metric_cc_tokens__ = [[["java", "js", "c", "cc", "cpp","groovy"], ["else", r"for\s+\(.*\)", r"if\s+\(.*\)", r"case\s+\w+:",
                                                             "default:", r"while\s+\(.*\)"],
                                                            ["assert", "break", "continue", "return"]],
                        [["cs"], ["else", r"for\s+\(.*\)", r"foreach\s+\(.*\)", r"goto\s+\w+:", r"if\s+\(.*\)", r"case\s+\w+:",


### PR DESCRIPTION
I found when using the -f flag that if I did not have any files that matched the -f arguments, I would get exceptions because self.commits contained NoneType commits. This patch prevents that situation from occurring through guard clauses and filtering out those unwanted entries.

Here's an example of the error:

```
$ git inspector -f md
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/Users/neontapir/git/github/neontapir/gitinspector/gitinspector/changes.py", line 170, in run
    commit.add_filediff(filediff)
AttributeError: 'NoneType' object has no attribute 'add_filediff'
```