### PR TITLE
chore: bump version for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitinspector",
-  "version": "0.5.0-dev-1",
+  "version": "0.5.0-dev-2",
   "description": "Gitinspector is a statistical analysis tool for git repositories. The default analysis shows general statistics per author, which can be complemented with a timeline analysis that shows the workload and activity of each author.",
   "preferGlobal": true,
   "main": "gitinspector.py",


### PR DESCRIPTION
Just released a new build on npm, 0.5.0-dev-2, and updated the package.json file accordingly. Could you pull (fast-forward) this single change please?