### PR TITLE
Remove unused bufsize, fix install arg error

### DIFF
--- a/gitinspector/basedir.py
+++ b/gitinspector/basedir.py
@@ -34,7 +34,7 @@ def get_basedir_git(path=None):
 		previous_directory = os.getcwd()
 		os.chdir(path)
 
-	bare_command = subprocess.Popen(["git", "rev-parse", "--is-bare-repository"], bufsize=1,
+	bare_command = subprocess.Popen(["git", "rev-parse", "--is-bare-repository"],
 	                          stdout=subprocess.PIPE, stderr=open(os.devnull, "w"))
 
 	isbare = bare_command.stdout.readlines()
@@ -47,9 +47,9 @@ def get_basedir_git(path=None):
 	absolute_path = None
 
 	if isbare:
-		absolute_path = subprocess.Popen(["git", "rev-parse", "--git-dir"], bufsize=1, stdout=subprocess.PIPE).stdout
+		absolute_path = subprocess.Popen(["git", "rev-parse", "--git-dir"], stdout=subprocess.PIPE).stdout
 	else:
-		absolute_path = subprocess.Popen(["git", "rev-parse", "--show-toplevel"], bufsize=1,
+		absolute_path = subprocess.Popen(["git", "rev-parse", "--show-toplevel"],
 		                                 stdout=subprocess.PIPE).stdout
 
 	absolute_path = absolute_path.readlines()

--- a/gitinspector/blame.py
+++ b/gitinspector/blame.py
@@ -91,7 +91,7 @@ class BlameThread(threading.Thread):
 			__blame_lock__.release() # ...to here.
 
 	def run(self):
-		git_blame_r = subprocess.Popen(self.blame_command, bufsize=1, stdout=subprocess.PIPE).stdout
+		git_blame_r = subprocess.Popen(self.blame_command, stdout=subprocess.PIPE).stdout
 		rows = git_blame_r.readlines()
 		git_blame_r.close()
 
@@ -123,7 +123,7 @@ PROGRESS_TEXT = N_("Checking how many rows belong to each author (2 of 2): {0:.0
 class Blame(object):
 	def __init__(self, repo, hard, useweeks, changes):
 		self.blames = {}
-		ls_tree_p = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()], bufsize=1,
+		ls_tree_p = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()],
 		                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 		lines = ls_tree_p.communicate()[0].splitlines()
 		ls_tree_p.stdout.close()

--- a/gitinspector/changes.py
+++ b/gitinspector/changes.py
@@ -125,7 +125,7 @@ class ChangesThread(threading.Thread):
 		git_log_r = subprocess.Popen(filter(None, ["git", "log", "--reverse", "--pretty=%ct|%cd|%H|%aN|%aE",
 		                             "--stat=100000,8192", "--no-merges", "-w", interval.get_since(),
 		                             interval.get_until(), "--date=short"] + (["-C", "-C", "-M"] if self.hard else []) +
-		                             [self.first_hash + self.second_hash]), bufsize=1, stdout=subprocess.PIPE).stdout
+		                             [self.first_hash + self.second_hash]), stdout=subprocess.PIPE).stdout
 		lines = git_log_r.readlines()
 		git_log_r.close()
 
@@ -186,7 +186,7 @@ class Changes(object):
 		self.commits = []
 		interval.set_ref("HEAD");
 		git_rev_list_p = subprocess.Popen(filter(None, ["git", "rev-list", "--reverse", "--no-merges",
-		                                  interval.get_since(), interval.get_until(), "HEAD"]), bufsize=1,
+		                                  interval.get_since(), interval.get_until(), "HEAD"]),
 		                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 		lines = git_rev_list_p.communicate()[0].splitlines()
 		git_rev_list_p.stdout.close()

--- a/gitinspector/clone.py
+++ b/gitinspector/clone.py
@@ -42,7 +42,7 @@ def create(url):
 	if parsed_url.scheme == "file" or parsed_url.scheme == "git" or parsed_url.scheme == "http" or \
 	   parsed_url.scheme == "https" or parsed_url.scheme == "ssh":
 		path = tempfile.mkdtemp(suffix=".gitinspector")
-		git_clone = subprocess.Popen(["git", "clone", url, path], bufsize=1, stdout=sys.stderr)
+		git_clone = subprocess.Popen(["git", "clone", url, path], stdout=sys.stderr)
 		git_clone.wait()
 
 		if git_clone.returncode != 0:

--- a/gitinspector/config.py
+++ b/gitinspector/config.py
@@ -32,7 +32,7 @@ class GitConfig(object):
 		previous_directory = os.getcwd()
 		os.chdir(self.repo)
 		setting = subprocess.Popen(filter(None, ["git", "config", "--global" if self.global_only else "",
-		                           "inspector." + variable]), bufsize=1, stdout=subprocess.PIPE).stdout
+		                           "inspector." + variable]), stdout=subprocess.PIPE).stdout
 		os.chdir(previous_directory)
 
 		try:

--- a/gitinspector/filtering.py
+++ b/gitinspector/filtering.py
@@ -58,7 +58,7 @@ def has_filtered():
 	return False
 
 def __find_commit_message__(sha):
-	git_show_r = subprocess.Popen(filter(None, ["git", "show", "-s", "--pretty=%B", "-w", sha]), bufsize=1,
+	git_show_r = subprocess.Popen(filter(None, ["git", "show", "-s", "--pretty=%B", "-w", sha]),
 	                              stdout=subprocess.PIPE).stdout
 
 	commit_message = git_show_r.read()

--- a/gitinspector/localization.py
+++ b/gitinspector/localization.py
@@ -68,7 +68,7 @@ def init():
 
 		__enabled__ = True
 		__installed__ = True
-		__translation__.install(True)
+		__translation__.install()
 
 def check_compatibility(version):
 	if isinstance(__translation__, gettext.GNUTranslations):
@@ -93,7 +93,7 @@ def get_date():
 
 def enable():
 	if isinstance(__translation__, gettext.GNUTranslations):
-		__translation__.install(True)
+		__translation__.install()
 
 		global __enabled__
 		__enabled__ = True
@@ -103,4 +103,4 @@ def disable():
 	__enabled__ = False
 
 	if __installed__:
-		gettext.NullTranslations().install(True)
+		gettext.NullTranslations().install()

--- a/gitinspector/metrics.py
+++ b/gitinspector/metrics.py
@@ -44,7 +44,7 @@ class MetricsLogic(object):
 		self.cyclomatic_complexity = {}
 		self.cyclomatic_complexity_density = {}
 
-		ls_tree_p = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()], bufsize=1,
+		ls_tree_p = subprocess.Popen(["git", "ls-tree", "--name-only", "-r", interval.get_ref()],
 		                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 		lines = ls_tree_p.communicate()[0].splitlines()
 		ls_tree_p.stdout.close()
@@ -57,7 +57,7 @@ class MetricsLogic(object):
 
 				if FileDiff.is_valid_extension(i) and not filtering.set_filtered(FileDiff.get_filename(i)):
 					file_r = subprocess.Popen(["git", "show", interval.get_ref() + ":{0}".format(i.strip())],
-					                          bufsize=1, stdout=subprocess.PIPE).stdout.readlines()
+					                          stdout=subprocess.PIPE).stdout.readlines()
 
 					extension = FileDiff.get_extension(i)
 					lines = MetricsLogic.get_eloc(file_r, extension)
@@ -79,7 +79,7 @@ class MetricsLogic(object):
 			self.cyclomatic_complexity_density.update(other.cyclomatic_complexity_density)
 			return self
 		except AttributeError:
-			return other;
+			return other
 
 	@staticmethod
 	def get_cyclomatic_complexity(file_r, extension):


### PR DESCRIPTION
In recent version of Python, the bufsize arg in Popen calls triggers a warning. Previously, the argument was simply ignored.

Also, fix install arg error. True was passed as an argument where a list of names was expected (or None).