### PR TITLE
Fix TypeError for disabled localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.egg-info
 *.pyc
 *.tgz
+**/.DS_Store

--- a/gitinspector/localization.py
+++ b/gitinspector/localization.py
@@ -68,7 +68,7 @@ def init():
 
 		__enabled__ = True
 		__installed__ = True
-		__translation__.install(True)
+		__translation__.install()
 
 def check_compatibility(version):
 	if isinstance(__translation__, gettext.GNUTranslations):
@@ -103,4 +103,4 @@ def disable():
 	__enabled__ = False
 
 	if __installed__:
-		gettext.NullTranslations().install(True)
+		gettext.NullTranslations().install()


### PR DESCRIPTION
If the localization was not set ("WARNING: Localization disabled because the system language could not be determined.") the translation.install() was missing an argument, raising TypeError: 'bool' object is not iterable